### PR TITLE
Update provider version to 0.3.0 matching release, bug fix

### DIFF
--- a/provider/sdk/setup.py
+++ b/provider/sdk/setup.py
@@ -15,7 +15,7 @@ repo_root = str(pathlib.Path(__file__).resolve().parent.parent)
 
 # README file from Feast repo root directory
 README_FILE = os.path.join(repo_root, "README.md")
-with open(README_FILE, "r", encoding="mbcs") as f:
+with open(README_FILE, "r", encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 setup(


### PR DESCRIPTION
- Update feast-azure-provider setup.py to reflect 0.3.0 release version
- Fix aml dependency on inference container #49 