### PR TITLE
[Enhancement] Update deployment tutorial

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install protobuf==3.10
+          python -m pip install 'protobuf>=3.10,<3.20'
           python -m pip install db-dtypes 
           python -m pip install -e feast/sdk/python[ci]
       - name: Run Feast unit tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install protobuf==3.10
           python -m pip install db-dtypes 
           python -m pip install -e feast/sdk/python[ci]
       - name: Run Feast unit tests

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ The only 2 required parameters during the set-up are:
 - **Principal ID** this is to set the storage permissions for the feast registry store. You can find the value for this by opening **Cloud Shell** and run the following command:
 
 ```bash
+# If you are using Azure portal CLI or Azure CLI 2.37.0 or above
 az ad signed-in-user show --query id -o tsv
+
+# If you are using Azure CLI below 2.37.0
+az ad signed-in-user show --query objectId -o tsv
 ```
+
 ## Feast on Azure Kubernetes Service (AKS)
 The [Feast on AKS](./cluster/README.md) is a secure enterprise deployment on a customer provisioned AKS cluster in an Azure VNET. This deployment does not expose any public endpoints and leverages Azure Private Link over the Feast core and serving so that the traffic flows over the Microsoft Network. This deployment also supports secure connectivity from Azure Synapse Analytics and Azure Machine Learning via private endpoints.
 ### 📐 Architecture

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The only 2 required parameters during the set-up are:
 - **Principal ID** this is to set the storage permissions for the feast registry store. You can find the value for this by opening **Cloud Shell** and run the following command:
 
 ```bash
-az ad signed-in-user show --query objectId -o tsv
+az ad signed-in-user show --query id -o tsv
 ```
 ## Feast on Azure Kubernetes Service (AKS)
 The [Feast on AKS](./cluster/README.md) is a secure enterprise deployment on a customer provisioned AKS cluster in an Azure VNET. This deployment does not expose any public endpoints and leverages Azure Private Link over the Feast core and serving so that the traffic flows over the Microsoft Network. This deployment also supports secure connectivity from Azure Synapse Analytics and Azure Machine Learning via private endpoints.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ We recommend the [getting started tutorial](provider/tutorial/) that walks you t
 
 You can deploy the infrastructure for feast using:
 
+> You may want to first make sure your subscription has registered `Microsoft.Synapse`, `Microsoft.SQL` and `Microsoft.Network` providers before running the template below, as some of them may require explicit registration.
+
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Ffeast-azure%2Fmain%2Fprovider%2Fcloud%2Ffs_synapse_azuredeploy.json)
 
 The only 2 required parameters during the set-up are:

--- a/provider/README.md
+++ b/provider/README.md
@@ -32,7 +32,7 @@ The only 2 required parameters during the set-up are:
 - **Principal ID** this is to set the storage permissions for the feast registry store. You can find the value for this by opening **Cloud Shell** and run the following command:
 
 ```bash
-az ad signed-in-user show --query objectId -o tsv
+az ad signed-in-user show --query id -o tsv
 ```
 
 ## Note

--- a/provider/README.md
+++ b/provider/README.md
@@ -34,7 +34,11 @@ The only 2 required parameters during the set-up are:
 - **Principal ID** this is to set the storage permissions for the feast registry store. You can find the value for this by opening **Cloud Shell** and run the following command:
 
 ```bash
+# If you are using Azure portal CLI or Azure CLI 2.37.0 or above
 az ad signed-in-user show --query id -o tsv
+
+# If you are using Azure CLI below 2.37.0
+az ad signed-in-user show --query objectId -o tsv
 ```
 
 ## Note

--- a/provider/README.md
+++ b/provider/README.md
@@ -24,6 +24,8 @@ We recommend the [getting started tutorial](./tutorial) that walks you through a
 
 You can deploy the infrastructure for feast using:
 
+> You may want to first make sure your subscription has registered `Microsoft.Synapse`, `Microsoft.SQL` and `Microsoft.Network` providers before running the template below, as some of them may require explicit registration.
+
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Ffeast-azure%2Fmain%2Fprovider%2Fcloud%2Ffs_synapse_azuredeploy.json)
 
 The only 2 required parameters during the set-up are:

--- a/provider/cloud/fs_sqldb_azuredeploy.json
+++ b/provider/cloud/fs_sqldb_azuredeploy.json
@@ -11,7 +11,7 @@
         "principalId": {
             "type": "string",
             "metadata": {
-                "description": "Specifies the principal ID assigned to the role. You can find in cloud shell using 'az ad signed-in-user show --query objectId -o tsv'"
+                "description": "Specifies the principal ID assigned to the role. You can find in cloud shell using 'az ad signed-in-user show --query id -o tsv'"
             }
         },
         "administratorLogin": {
@@ -287,8 +287,7 @@
                     "dependsOn": [
                         "[resourceId('Microsoft.Sql/servers', concat(parameters('sqlServerName')))]"
                     ],
-                    "properties": {
-                    }
+                    "properties": {}
                 }
             ]
         },
@@ -337,7 +336,5 @@
             ]
         }
     ],
-    "outputs": {
-
-    }
+    "outputs": {}
 }

--- a/provider/cloud/fs_synapse_azuredeploy.json
+++ b/provider/cloud/fs_synapse_azuredeploy.json
@@ -11,7 +11,7 @@
         "principalId": {
             "type": "string",
             "metadata": {
-                "description": "Specifies the principal ID assigned to the role. You can find in cloud shell using 'az ad signed-in-user show --query objectId -o tsv'"
+                "description": "Specifies the principal ID assigned to the role. You can find in cloud shell using 'az ad signed-in-user show --query id -o tsv'"
             }
         },
         "sku": {
@@ -355,7 +355,9 @@
                     "apiVersion": "2019-06-01-preview",
                     "name": "allowAll",
                     "location": "[variables('location')]",
-                    "dependsOn": [ "[variables('workspaceName')]" ],
+                    "dependsOn": [
+                        "[variables('workspaceName')]"
+                    ],
                     "properties": {
                         "startIpAddress": "0.0.0.0",
                         "endIpAddress": "255.255.255.255"
@@ -366,7 +368,9 @@
                     "apiVersion": "2019-06-01-preview",
                     "name": "AllowAllWindowsAzureIps",
                     "location": "[variables('location')]",
-                    "dependsOn": [ "[variables('workspaceName')]" ],
+                    "dependsOn": [
+                        "[variables('workspaceName')]"
+                    ],
                     "properties": {
                         "startIpAddress": "0.0.0.0",
                         "endIpAddress": "0.0.0.0"
@@ -377,7 +381,9 @@
                     "apiVersion": "2019-06-01-preview",
                     "name": "default",
                     "location": "[variables('location')]",
-                    "dependsOn": [ "[variables('workspaceName')]" ],
+                    "dependsOn": [
+                        "[variables('workspaceName')]"
+                    ],
                     "properties": {
                         "grantSqlControlToManagedIdentity": {
                             "desiredState": "Enabled"
@@ -403,7 +409,5 @@
             }
         }
     ],
-    "outputs": {
-
-    }
+    "outputs": {}
 }

--- a/provider/tutorial/README.md
+++ b/provider/tutorial/README.md
@@ -24,7 +24,11 @@ The only 2 required parameters during the set-up are:
 - **Principal ID** this is to set the storage permissions for the feast registry store. You can find the value for this by opening **Cloud Shell** and run the following command:
 
 ```bash
+# If you are using Azure portal CLI or Azure CLI 2.37.0 or above
 az ad signed-in-user show --query id -o tsv
+
+# If you are using Azure CLI below 2.37.0
+az ad signed-in-user show --query objectId -o tsv
 ```
 
 > You may want to first make sure your subscription has registered `Microsoft.Synapse`, `Microsoft.SQL` and `Microsoft.Network` providers before running the template below, as some of them may require explicit registration.

--- a/provider/tutorial/README.md
+++ b/provider/tutorial/README.md
@@ -26,6 +26,9 @@ The only 2 required parameters during the set-up are:
 ```bash
 az ad signed-in-user show --query id -o tsv
 ```
+
+> You may want to first make sure your subscription has registered `Microsoft.Synapse`, `Microsoft.SQL` and `Microsoft.Network` providers before running the template below, as some of them may require explicit registration.
+
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Ffeast-azure%2Fmain%2Fprovider%2Fcloud%2Ffs_synapse_azuredeploy.json)
 
 ![feast architecture](media/arch.png)

--- a/provider/tutorial/README.md
+++ b/provider/tutorial/README.md
@@ -72,3 +72,5 @@ In the Azure ML Studio, select *Notebooks* from the left-hand menu and then open
 In the Azure ML Studio, select *Notebooks* from the left-hand menu and then open the [train and deploy a model using feast notebook](notebooks/part3-train-and-deploy-with-feast.ipynb). Work through this notebook.
 
 > __💁Ensure the Jupyter kernel is set to Python 3.8 - AzureML__
+>
+> If problems are encountered during model training stage, create a new cell and rexecute `!pip install scikit-learn==0.22.1`. Upon completion, restart the Kernel and start over.

--- a/provider/tutorial/README.md
+++ b/provider/tutorial/README.md
@@ -24,7 +24,7 @@ The only 2 required parameters during the set-up are:
 - **Principal ID** this is to set the storage permissions for the feast registry store. You can find the value for this by opening **Cloud Shell** and run the following command:
 
 ```bash
-az ad signed-in-user show --query objectId -o tsv
+az ad signed-in-user show --query id -o tsv
 ```
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Ffeast-azure%2Fmain%2Fprovider%2Fcloud%2Ffs_synapse_azuredeploy.json)
 

--- a/provider/tutorial/notebooks/inference.dockerfile
+++ b/provider/tutorial/notebooks/inference.dockerfile
@@ -10,8 +10,8 @@ ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 RUN apt-get install -y gcc
 RUN apt-get install -y unixodbc-dev
 
-RUN pip install 'azureml-defaults==1.35.0' \
-                'feast-azure-provider==0.3.0' \
-                'scikit-learn==0.22.2.post1' \
-		        'joblib===1.1.0' \
-                'itsdangerous==2.0.1'
+RUN pip install 'azureml-defaults==1.42.0' \
+    'feast-azure-provider==0.3.0' \
+    'scikit-learn==0.22.2.post1' \
+    'joblib===1.1.0' \
+    'itsdangerous==2.0.1'

--- a/provider/tutorial/notebooks/inference.dockerfile
+++ b/provider/tutorial/notebooks/inference.dockerfile
@@ -10,7 +10,9 @@ ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 RUN apt-get install -y gcc
 RUN apt-get install -y unixodbc-dev
 
-RUN pip install 'azureml-defaults==1.42.0' \
+RUN pip install \
+    'protobuf<=3.20' \
+    'azureml-defaults==1.42.0' \
     'feast-azure-provider==0.3.0' \
     'scikit-learn==0.22.2.post1' \
     'joblib===1.1.0' \

--- a/provider/tutorial/notebooks/inference.dockerfile
+++ b/provider/tutorial/notebooks/inference.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get install -y gcc
 RUN apt-get install -y unixodbc-dev
 
 RUN pip install \
-    'protobuf<=3.20' \
+    'protobuf>=3.10,<3.20' \
     'azureml-defaults==1.42.0' \
     'feast-azure-provider==0.3.0' \
     'scikit-learn==0.22.2.post1' \

--- a/provider/tutorial/notebooks/part3-train-and-deploy-with-feast.ipynb
+++ b/provider/tutorial/notebooks/part3-train-and-deploy-with-feast.ipynb
@@ -347,6 +347,22 @@
         "\n",
         "service.run(input_data=input_payload)"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Clean up service"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "service.delete()"
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION
Update and fix issues in tutorials

- `jinja2` 3.1 was release in Mar 2022, which causes an `ImportError` in `azure-default`
  - Related issue is https://github.com/MicrosoftDocs/azure-docs/issues/90567, and newer `azure-default` was released.
  - Update azure-default dependency to 1.42.0 in the `inference.dockerfile`.

- `protobuf` 3.20 and 4.21 was release in Apr - May 2022, which is incompatible with `feast`
  - Will cause `TypeError` when importing using 4.21; and there are some non backward compatible api release in 3.20.
  - Related issue in `feast` https://github.com/feast-dev/feast/issues/2484. 
  - Restrict `3.10 <= protobuf < 3.20` in the `inference.dockerfile`.
  - Restrict `3.10 <= protobuf < 3.20` in the unit test pipeline.

- `objectId` was changed to `id` in Microsoft Graph API
  - Related documentation: https://docs.microsoft.com/cli/azure/microsoft-graph-migration.
  - Change tutorial instruction to use `az ad signed-in-user show --query id -o tsv` to find principal id instead.

- The default `scikit-learn` in AzureML may not be compatible with some features in the notebook.
  - Some issues are:
    - `mlflow.sklearn.autolog()` will lead to an `ImportError`.
    - Experiment is not outputting any models upon completion.
  - These issues can be tackled by manually installing `scikit-learn==0.22.1` in the workspace.
  - Reference: https://docs.microsoft.com/en-us/azure/machine-learning/tutorial-train-deploy-notebook#install-packages

- Add a clean up block to delete unused service at the end of the tutorial


Closes: #57 